### PR TITLE
Some minor improvements

### DIFF
--- a/minimal/flake.nix
+++ b/minimal/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "You new nix config";
+  description = "Your new nix config";
 
   inputs = {
     # Nixpkgs

--- a/minimal/nixos/configuration.nix
+++ b/minimal/nixos/configuration.nix
@@ -62,7 +62,7 @@
     };
   };
 
-  # This setups a SSH server. Very important if you're setting up a headless system.
+  # This sets up a SSH server. Very important if you're setting up a headless system.
   # Feel free to remove if you don't need it.
   services.openssh = {
     enable = true;

--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "You new nix config";
+  description = "Your new nix config";
 
   inputs = {
     # Nixpkgs
@@ -41,7 +41,7 @@
       homeManagerModules = import ./modules/home-manager;
 
       # Devshell for bootstrapping
-      # Acessible through 'nix develop' or 'nix-shell' (legacy)
+      # Accessible through 'nix develop' or 'nix-shell' (legacy)
       devShells = forAllSystems (system: {
         default = legacyPackages.${system}.callPackage ./shell.nix { };
       });

--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -63,14 +63,6 @@
         }
       );
 
-      # Export your custom packages
-      # These will be listed in 'nix flake show'
-      packages = forAllSystems (system:
-        import ./pkgs {
-          pkgs = nixpkgs.legacyPackages.${system};
-        }
-      );
-
       nixosConfigurations = {
         # FIXME replace with your hostname
         your-hostname = nixpkgs.lib.nixosSystem {

--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -63,6 +63,14 @@
         }
       );
 
+      # Export your custom packages
+      # These will be listed in 'nix flake show'
+      packages = forAllSystems (system:
+        import ./pkgs {
+          pkgs = nixpkgs.legacyPackages.${system};
+        }
+      );
+
       nixosConfigurations = {
         # FIXME replace with your hostname
         your-hostname = nixpkgs.lib.nixosSystem {

--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -43,7 +43,7 @@
       # Devshell for bootstrapping
       # Accessible through 'nix develop' or 'nix-shell' (legacy)
       devShells = forAllSystems (system: {
-        default = legacyPackages.${system}.callPackage ./shell.nix { };
+        default = nixpkgs.legacyPackages.${system}.callPackage ./shell.nix { };
       });
 
       # This instantiates nixpkgs for each system listed above

--- a/standard/shell.nix
+++ b/standard/shell.nix
@@ -1,6 +1,6 @@
 # Shell for bootstrapping flake-enabled nix and home-manager
 { pkgs ? let
-    # If pkgs is not defined, instanciate nixpkgs from locked commit
+    # If pkgs is not defined, instantiate nixpkgs from locked commit
     lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
     nixpkgs = fetchTarball {
       url = "https://github.com/nixos/nixpkgs/archive/${lock.rev}.tar.gz";


### PR DESCRIPTION
1. Fixed a few misspellings.
2. Added `packages` output.
3. Use the same nixpkgs in `nix-shell` and `nix develop`. Unlikely to ever actually be a problem, but they should still be the same.

This should maybe be 3 separate PRs, but since they would each be so minor I didn't bother.

Finally, thanks for putting out such clear templates! I've been using flakes for nearly 2 years, but when I came across this repo recently I immediately refactored my own configs to more closely resemble your standard template. It helped me understand flakes better, and the result is much simpler and more organized.