### PR TITLE
add `nix fmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "NixOS + standalone home-manager config flakes to get you started!";
+  description =
+    "NixOS + standalone home-manager config flakes to get you started!";
   outputs = inputs: {
     templates = {
       minimal = {

--- a/minimal/flake.nix
+++ b/minimal/flake.nix
@@ -33,12 +33,16 @@
     # Available through 'home-manager --flake .#your-username@your-hostname'
     homeConfigurations = {
       # FIXME replace with your username@hostname
-      "your-username@your-hostname" = home-manager.lib.homeManagerConfiguration {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux; # Home-manager requires 'pkgs' instance
-        extraSpecialArgs = { inherit inputs; }; # Pass flake inputs to our config
-        # > Our main home-manager configuration file <
-        modules = [ ./home-manager/home.nix ];
-      };
+      "your-username@your-hostname" =
+        home-manager.lib.homeManagerConfiguration {
+          pkgs =
+            nixpkgs.legacyPackages.x86_64-linux; # Home-manager requires 'pkgs' instance
+          extraSpecialArgs = {
+            inherit inputs;
+          }; # Pass flake inputs to our config
+          # > Our main home-manager configuration file <
+          modules = [ ./home-manager/home.nix ];
+        };
     };
   };
 }

--- a/minimal/nixos/configuration.nix
+++ b/minimal/nixos/configuration.nix
@@ -42,7 +42,8 @@
 
     # This will additionally add your inputs to the system's legacy channels
     # Making legacy nix commands consistent as well, awesome!
-    nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}") config.nix.registry;
+    nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}")
+      config.nix.registry;
 
     settings = {
       # Enable flakes and new 'nix' command

--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -31,20 +31,21 @@
         "aarch64-darwin"
         "x86_64-darwin"
       ];
-    in
-    rec {
+    in rec {
       # Your custom packages
       # Acessible through 'nix build', 'nix shell', etc
       packages = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
-        in import ./pkgs { inherit pkgs; }
-      );
+        in import ./pkgs { inherit pkgs; });
       # Devshell for bootstrapping
       # Acessible through 'nix develop' or 'nix-shell' (legacy)
       devShells = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
-        in import ./shell.nix { inherit pkgs; }
-      );
+        in import ./shell.nix { inherit pkgs; });
+
+      formatter = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in pkgs.nixpkgs-fmt);
 
       # Your custom packages and modifications, exported as overlays
       overlays = import ./overlays { inherit inputs; };
@@ -72,14 +73,16 @@
       # Available through 'home-manager --flake .#your-username@your-hostname'
       homeConfigurations = {
         # FIXME replace with your username@hostname
-        "your-username@your-hostname" = home-manager.lib.homeManagerConfiguration {
-          pkgs = nixpkgs.legacyPackages.x86_64-linux; # Home-manager requires 'pkgs' instance
-          extraSpecialArgs = { inherit inputs outputs; };
-          modules = [
-            # > Our main home-manager configuration file <
-            ./home-manager/home.nix
-          ];
-        };
+        "your-username@your-hostname" =
+          home-manager.lib.homeManagerConfiguration {
+            pkgs =
+              nixpkgs.legacyPackages.x86_64-linux; # Home-manager requires 'pkgs' instance
+            extraSpecialArgs = { inherit inputs outputs; };
+            modules = [
+              # > Our main home-manager configuration file <
+              ./home-manager/home.nix
+            ];
+          };
       };
     };
 }

--- a/standard/nixos/configuration.nix
+++ b/standard/nixos/configuration.nix
@@ -50,7 +50,8 @@
 
     # This will additionally add your inputs to the system's legacy channels
     # Making legacy nix commands consistent as well, awesome!
-    nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}") config.nix.registry;
+    nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}")
+      config.nix.registry;
 
     settings = {
       # Enable flakes and new 'nix' command

--- a/standard/nixpkgs.nix
+++ b/standard/nixpkgs.nix
@@ -1,8 +1,9 @@
 # A nixpkgs instance that is grabbed from the pinned nixpkgs commit in the lock file
 # This is useful to avoid using channels when using legacy nix commands
-let lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
-in
-import (fetchTarball {
+let
+  lock =
+    (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
+in import (fetchTarball {
   url = "https://github.com/nixos/nixpkgs/archive/${lock.rev}.tar.gz";
   sha256 = lock.narHash;
 })

--- a/standard/overlays/default.nix
+++ b/standard/overlays/default.nix
@@ -1,17 +1,17 @@
 # This file defines overlays
-{ inputs, ... }:
-{
+{ inputs, ... }: {
   # This one brings our custom packages from the 'pkgs' directory
   additions = final: _prev: import ../pkgs { pkgs = final; };
 
   # This one contains whatever you want to overlay
   # You can change versions, add patches, set compilation flags, anything really.
   # https://nixos.wiki/wiki/Overlays
-  modifications = final: prev: {
-    # example = prev.example.overrideAttrs (oldAttrs: rec {
-    # ...
-    # });
-  };
+  modifications = final: prev:
+    {
+      # example = prev.example.overrideAttrs (oldAttrs: rec {
+      # ...
+      # });
+    };
 
   # When applied, the unstable nixpkgs set (declared in the flake inputs) will
   # be accessible through 'pkgs.unstable'

--- a/standard/pkgs/default.nix
+++ b/standard/pkgs/default.nix
@@ -1,6 +1,7 @@
 # Custom packages, that can be defined similarly to ones from nixpkgs
 # You can build them using 'nix build .#example' or (legacy) 'nix-build -A example'
 
-{ pkgs ? (import ../nixpkgs.nix) { } }: {
+{ pkgs ? (import ../nixpkgs.nix) { } }:
+{
   # example = pkgs.callPackage ./example { };
 }


### PR DESCRIPTION
First of all thank you for this wonderful template. It was very easy to migrate from the old configuration format to flakes.
I added support for the `nix fmt` command to standard flake & formatted all existing files with nixfmt.