### PR TITLE
Update README for "Use home-manager as a NixOS module"

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,21 +115,25 @@ add this to your NixOS configuration (either directly on
 `nixos/configuration.nix` or on a separate file and import it):
 
 ```nix
-{ inputs, ... }: {
+{ inputs, outputs, ... }: {
   imports = [
     # Import home-manager's NixOS module
     inputs.home-manager.nixosModules.home-manager
   ];
 
   home-manager = {
-    extraSpecialArgs = { inherit inputs; };
+    extraSpecialArgs = { inherit inputs outputs; };
     users = {
       # Import your home-manager configuration
+      # Note: this assumes you have a `default.nix` in your home-manager directory.
+      # If not replace with the `your-username = import ../home-manager/home.nix` 
       your-username = import ../home-manager;
     };
   };
 }
 ```
+
+> Note: The above is applicable to the standard version; for the minimal version the `flake.nix` does not pass `outputs` through `specialArgs`.
 
 ## Adding more hosts or users
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,7 @@ add this to your NixOS configuration (either directly on
     extraSpecialArgs = { inherit inputs outputs; };
     users = {
       # Import your home-manager configuration
-      # Note: this assumes you have a `default.nix` in your home-manager directory.
-      # If not replace with `your-username = import ../home-manager/home.nix` 
-      your-username = import ../home-manager;
+      your-username = import ../home-manager/home.nix;
     };
   };
 }

--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ add this to your NixOS configuration (either directly on
 }
 ```
 
-> Note: The above is applicable to the standard version; for the minimal version the `flake.nix` does not pass `outputs` through `specialArgs`.
-
 ## Adding more hosts or users
 
 You can organize them by hostname and username on `nixos` and `home-manager`

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ add this to your NixOS configuration (either directly on
     users = {
       # Import your home-manager configuration
       # Note: this assumes you have a `default.nix` in your home-manager directory.
-      # If not replace with the `your-username = import ../home-manager/home.nix` 
+      # If not replace with `your-username = import ../home-manager/home.nix` 
       your-username = import ../home-manager;
     };
   };


### PR DESCRIPTION
As mentioned in issue #30 the README needs to be corrected to use home-manager as a NixOS module. I think this should be the correct instructions :)