### PR TITLE
Use updated option for openssh settings

### DIFF
--- a/minimal/nixos/configuration.nix
+++ b/minimal/nixos/configuration.nix
@@ -86,10 +86,12 @@
   # Feel free to remove if you don't need it.
   services.openssh = {
     enable = true;
-    # Forbid root login through SSH.
-    permitRootLogin = "no";
-    # Use keys only. Remove if you want to SSH using password (not recommended)
-    passwordAuthentication = false;
+    settings = {
+      # Forbid root login through SSH.
+      PermitRootLogin = "no";
+      # Use keys only. Remove if you want to SSH using password (not recommended)
+      PasswordAuthentication = false;
+    };
   };
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion

--- a/standard/nixos/configuration.nix
+++ b/standard/nixos/configuration.nix
@@ -95,10 +95,12 @@
   # Feel free to remove if you don't need it.
   services.openssh = {
     enable = true;
-    # Forbid root login through SSH.
-    permitRootLogin = "no";
-    # Use keys only. Remove if you want to SSH using password (not recommended)
-    passwordAuthentication = false;
+    settings = {
+      # Forbid root login through SSH.
+      PermitRootLogin = "no";
+      # Use keys only. Remove if you want to SSH using password (not recommended)
+      PasswordAuthentication = false;
+    };
   };
 
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion


### PR DESCRIPTION
When running, a warning is emitted.
```
warning: The option `services.openssh.permitRootLogin' defined in `/nix/store/.../minimal/nixos/configuration.nix' has been renamed to `services.openssh.settings.PermitRootLogin'.
warning: The option `services.openssh.passwordAuthentication' defined in `/nix/store/.../minimal/nixos/configuration.nix' has been renamed to `services.openssh.settings.PasswordAuthentication'.
```

This change updates the setting to match the new option path/name.
- [services.openssh.settings.PermitRootLogin](https://search.nixos.org/options?channel=23.05&show=services.openssh.settings.PermitRootLogin&type=packages)
- [services.openssh.settings.PasswordAuthentication](https://search.nixos.org/options?channel=23.05&show=services.openssh.settings.PasswordAuthentication&type=packages)
