### PR TITLE
fix: Workaround for  `allowUnfreePredicate` is solved

### DIFF
--- a/standard/home-manager/home.nix
+++ b/standard/home-manager/home.nix
@@ -42,8 +42,6 @@
     config = {
       # Disable if you don't want unfree packages
       allowUnfree = true;
-      # Workaround for https://github.com/nix-community/home-manager/issues/2942
-      allowUnfreePredicate = _: true;
     };
   };
 


### PR DESCRIPTION
I think this workaround can be removed. I am however not sure in which version of home-manager that came in.

Probably we cannot yet merge this since its not in `release-23.05` branch as this templates refer to.

https://github.com/nix-community/home-manager/pull/4304