### PR TITLE
Broken `NIX_PATH` workaround

### DIFF
--- a/minimal/nixos/configuration.nix
+++ b/minimal/nixos/configuration.nix
@@ -48,6 +48,8 @@
       experimental-features = "nix-command flakes";
       # Opinionated: disable global registry
       flake-registry = "";
+      # Workaround for https://github.com/NixOS/nix/issues/9574
+      nix-path = config.nix.nixPath;
     };
     # Opinionated: disable channels
     channel.enable = false;

--- a/standard/nixos/configuration.nix
+++ b/standard/nixos/configuration.nix
@@ -57,6 +57,8 @@
       experimental-features = "nix-command flakes";
       # Opinionated: disable global registry
       flake-registry = "";
+      # Workaround for https://github.com/NixOS/nix/issues/9574
+      nix-path = config.nix.nixPath;
     };
     # Opinionated: disable channels
     channel.enable = false;


### PR DESCRIPTION
Commit 8204a49 disables channels which breaks `NIX_PATH` functionality due to https://github.com/NixOS/nix/issues/9574.

This adds a workaround.