### PR TITLE
added TODO to change architecture for home manager if necessary

### DIFF
--- a/standard/flake.nix
+++ b/standard/flake.nix
@@ -67,7 +67,7 @@
     homeConfigurations = {
       # FIXME replace with your username@hostname
       "your-username@your-hostname" = home-manager.lib.homeManagerConfiguration {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux; # Home-manager requires 'pkgs' instance
+        pkgs = nixpkgs.legacyPackages.x86_64-linux; # TODO replace x86_64-linux with your architecure, Home-manager requires 'pkgs' instance
         extraSpecialArgs = {inherit inputs outputs;};
         modules = [
           # > Our main home-manager configuration file <


### PR DESCRIPTION
I was running your standard starter config (great work btw ;) ) on a Raspberry Pi and Home Manager wasn't able to switch to the flake. The fix was pretty simple: adjust the architecture in line 70 to the architecture of your system. 

To give a hint for future users I added a TODO in this line

If there is a better way to do this automatically (like line 25-34) I am happy to adjust the script